### PR TITLE
Fix og:image on posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,13 +53,13 @@ defaults:
       lang: ja_JP
       show_sidebar: true
       hero_height: is-small
+      image: /images/ogp.png
   -
     scope:
       path: ""
       type: "pages"
     values:
       layout: page
-      image: /images/ogp.png
   -
     scope:
       path: ""

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,9 +1,4 @@
 <div class="card">
-    {% if post.image %}
-    <div class="card-image">
-        <img src="{{ post.image }}" alt="{{ post.title }}">
-    </div>
-    {% else %}
     <header class="card-header">
         {% if post.subtitle %}
           <a class="card-header-title" href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}<br>{{ post.subtitle }}</a>
@@ -11,12 +6,9 @@
           <a class="card-header-title" href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
         {% endif %}
     </header>
-    {% endif %}
+
     <div class="card-content">
         <div class="content">
-            {% if post.image %}
-            <a class="title is-4" href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
-            {% endif %}
             <p>{{ post.excerpt }}</p>
         </div>
         <div class="has-text-centered">


### PR DESCRIPTION
どのページでもog:imageにOS4ロゴ画像が設定されるようにしています。

postのヘッダー部分(Front Matter)に「image: (画像パス)」を入れれば、そちらの画像が設定されます。
ウェブサイト上にこれらの画像が表示されることはありません。

Front Matterで設定された画像を、どこか表示するようにした方がよいかもしれません。それは別途対応したいと思います。